### PR TITLE
Use callback instead of htmlCallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
         patterns: [{
           match: /<\/head>/i,
           replacement: function() {
-            return htmlCache + '\n</head>';
+            return (htmlCache || '') + '\n</head>';
           }
         }]
       });

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
 
   included: function(app) {
     this.options = app.favicons || {};
-    this.options.htmlCallback = function(html) {
+    this.options.callback = function(html) {
       htmlCache = html;
     };
   },


### PR DESCRIPTION
Currently the html appended on the index.html is `null` because the `htmlCallback` is never called. Changing the function name from `htmlCallback` to `callback` fixes this issue.
