### PR TITLE
Readme: Fix config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Just save an image to `public/favicon.png` (try to make sure it's at least 256x2
 ```js
 // ember-cli-build.js
 var app = new EmberApp({
-  favicon: {
-    config: {
+  favicons: {
+    faviconsConfig: {
       // these options are passed directly to the favicons module
     }
   }


### PR DESCRIPTION
Config example from the readme contradicts both [the addon itself](https://github.com/davewasmer/ember-cli-favicon/blob/master/index.js#L16) and [broccoli-favicon](https://github.com/davewasmer/broccoli-favicon/blob/master/index.js#L41).

It took me quite a while to figure out! :weary: 